### PR TITLE
#4: Fixed stack overflow error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,17 @@
 
 ## [Unreleased]
 
+## [1.0.1] - 2022-02-08
+### Removed
+- Unused `retract` directive from `go.mod`.
+
+### Fixed
+- Stack overflow error on the new version not found error.
+
 ## [1.0.0] - 2022-02-01
 ### Added
 - First release of Go Proxy.
 
-[Unreleased]: https://github.com/livesport-tv/goproxy/compare/v1.0.0...master
+[Unreleased]: https://github.com/livesport-tv/goproxy/compare/v1.0.1...master
+[1.0.1]: https://github.com/livesport-tv/goproxy/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/livesport-tv/goproxy/releases/tag/v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,6 @@ require (
 	github.com/stretchr/testify v1.7.0
 )
 
-// Module fallthrough is done by go install.
-retract v1.2.1
-
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,12 +1,12 @@
 openapi: 3.0.3
 info:
   description: "Go proxy with monorepo support (more projects with `go.mod` and different versions in the same GIT repository)."
-  version: "1.0.0"
+  version: "1.0.1"
   title: "Go Proxy"
   contact:
     name: "maintainer"
     email: "goproxy@livesporttv.cz"
-    url: "https://livesporttv.cz/"
+    url: "https://lstv.dev/"
 tags:
   - name: "common"
   - name: "modules"

--- a/source/source.go
+++ b/source/source.go
@@ -7,6 +7,7 @@ package source
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"sync"
 
@@ -36,10 +37,10 @@ func (v *VersionNotFoundError) Unwrap() error {
 }
 
 func (v *VersionNotFoundError) Error() string {
-	if v == nil {
+	if v == nil || v.Err == nil {
 		return "version not found"
 	}
-	return v.Error()
+	return fmt.Sprintf("version not found: %s", v.Err.Error())
 }
 
 func IsVersionNotFound(err error) bool {

--- a/source/source_test.go
+++ b/source/source_test.go
@@ -1,0 +1,128 @@
+package source
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_NewVersionNotFoundError(t *testing.T) {
+	err := errors.New("error")
+	candidates := []struct {
+		err         error
+		expectedErr *VersionNotFoundError
+	}{
+		// 0
+		{
+			err: err,
+			expectedErr: &VersionNotFoundError{
+				Err: err,
+			},
+		},
+		// 1
+		{
+			err: nil,
+			expectedErr: &VersionNotFoundError{
+				Err: nil,
+			},
+		},
+	}
+
+	for i, candidate := range candidates {
+		newVersionNotFoundErr := NewVersionNotFoundError(candidate.err)
+		assert.Error(t, newVersionNotFoundErr, "candidate %d", i)
+		assert.Equal(t, candidate.expectedErr, newVersionNotFoundErr, "candidate %d", i)
+	}
+}
+
+func Test_VersionNotFoundError_Unwrap(t *testing.T) {
+	err := errors.New("error")
+	candidates := []struct {
+		err         error
+		expectedErr error
+	}{
+		// 0
+		{
+			err:         err,
+			expectedErr: err,
+		},
+		// 1
+		{
+			err:         nil,
+			expectedErr: nil,
+		},
+	}
+
+	for i, candidate := range candidates {
+		newVersionNotFoundErr := NewVersionNotFoundError(candidate.err)
+		unwrappedErr := newVersionNotFoundErr.Unwrap()
+		assert.Equal(t, candidate.expectedErr, unwrappedErr, "candidate %d", i)
+	}
+}
+
+func Test_VersionNotFoundError_Error(t *testing.T) {
+	err := errors.New("error")
+	candidates := []struct {
+		err                  *VersionNotFoundError
+		expectedErrorMessage string
+	}{
+		// 0
+		{
+			err: &VersionNotFoundError{
+				Err: err,
+			},
+			expectedErrorMessage: "version not found: error",
+		},
+		// 1
+		{
+			err: &VersionNotFoundError{
+				Err: nil,
+			},
+			expectedErrorMessage: "version not found",
+		},
+		// 2
+		{
+			err:                  nil,
+			expectedErrorMessage: "version not found",
+		},
+	}
+
+	for i, candidate := range candidates {
+		errorMessage := candidate.err.Error()
+		assert.Equal(t, candidate.expectedErrorMessage, errorMessage, "candidate %d", i)
+	}
+}
+
+func Test_IsVersionNotFound(t *testing.T) {
+	err := errors.New("error")
+	candidates := []struct {
+		err                       error
+		expectedIsVersionNotFound bool
+	}{
+		// 0
+		{
+			err: &VersionNotFoundError{
+				Err: err,
+			},
+			expectedIsVersionNotFound: true,
+		},
+		// 1
+		{
+			err: &VersionNotFoundError{
+				Err: nil,
+			},
+			expectedIsVersionNotFound: true,
+		},
+		// 2
+		{
+			err:                       err,
+			expectedIsVersionNotFound: false,
+		},
+	}
+
+	for i, candidate := range candidates {
+		isVersionNotFound := IsVersionNotFound(candidate.err)
+		assert.Equal(t, candidate.expectedIsVersionNotFound, isVersionNotFound, "candidate %d", i)
+	}
+}


### PR DESCRIPTION
# Description

## [1.0.1] - 2022-02-08
### Removed
- Unused `retract` directive from `go.mod`.

### Fixed
- Stack overflow error on the new version not found error.

Closes #4

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).

# How Has This Been Tested?

How to test:

- [x] Place a non-existing Gitlab module version in `go.mod`.
- [x] Run `go mod tidy`.

or

- [x] `curl -v http://localhost:8080/<module>/@v/<non-existing-version>.info`.

The Go Proxy now correctly returns 404.

**Run Configuration**:
- Go Proxy version: `1.0.0`
- Go version: `1.17.6`
- Operating system: `Ubuntu 20.04.3 LTS`
- Processor architecture: `amd64`

# Checklist:

- [x] Pull request is linked with the corresponding issue.
- [x] My code follows the style guidelines of this project.
- [x] My change is documented in `CHANGELOG.md`.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (`README.md`, `openapi.yaml`).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

@schenkova @bafrnec
