### PR TITLE
#6: Fixed Docker app version propagation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,6 +169,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            GOPROXY_VERSION=$VERSION
+            GOPROXY_VERSION=${{ env.VERSION }}
             BUILD_DATE=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}     
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [1.0.2] - 2022-02-09
+### Fixed
+- App version did not propagate to Docker image.
+
 ## [1.0.1] - 2022-02-08
 ### Removed
 - Unused `retract` directive from `go.mod`.
@@ -13,6 +17,7 @@
 ### Added
 - First release of Go Proxy.
 
-[Unreleased]: https://github.com/livesport-tv/goproxy/compare/v1.0.1...master
+[Unreleased]: https://github.com/livesport-tv/goproxy/compare/v1.0.2...master
+[1.0.2]: https://github.com/livesport-tv/goproxy/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/livesport-tv/goproxy/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/livesport-tv/goproxy/releases/tag/v1.0.0

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   description: "Go proxy with monorepo support (more projects with `go.mod` and different versions in the same GIT repository)."
-  version: "1.0.1"
+  version: "1.0.2"
   title: "Go Proxy"
   contact:
     name: "maintainer"


### PR DESCRIPTION
# Description

## [1.0.2] - 2022-02-09
### Fixed
- App version did not propagate to Docker image.

Closes #6 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

# How Has This Been Tested?

Docker image was built in a separate repository.

# Checklist:

- [x] Pull request is linked with the corresponding issue.
- [x] My code follows the style guidelines of this project.
- [x] My change is documented in `CHANGELOG.md`.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (`README.md`, `openapi.yaml`).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

@schenkova @bafrnec
