### PR TITLE
#11: MacOS build fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [1.0.4] - 2022-03-17
+### Changed
+- Updated:
+  - `golang.org/x/sys`  to `v0.0.0-20220317061510-51cd9980dadf` (indirect dependency)
+
+### Fixed
+- MacOS build by updating `golang.org/x/sys`.
+
 ## [1.0.3] - 2022-03-17
 ### Changed
 - Updated to Go 1.18.
@@ -23,7 +31,8 @@
 ### Added
 - First release of Go Proxy.
 
-[Unreleased]: https://github.com/livesport-tv/goproxy/compare/v1.0.3...master
+[Unreleased]: https://github.com/livesport-tv/goproxy/compare/v1.0.4...master
+[1.0.4]: https://github.com/livesport-tv/goproxy/compare/v1.0.3...v1.0.4
 [1.0.3]: https://github.com/livesport-tv/goproxy/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/livesport-tv/goproxy/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/livesport-tv/goproxy/compare/v1.0.0...v1.0.1

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,6 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 // indirect
+	golang.org/x/sys v0.0.0-20220317061510-51cd9980dadf // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,9 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220317061510-51cd9980dadf h1:Fm4IcnUL803i92qDlmB0obyHmosDrxZWxJL3gIeNqOw=
+golang.org/x/sys v0.0.0-20220317061510-51cd9980dadf/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   description: "Go proxy with monorepo support (more projects with `go.mod` and different versions in the same GIT repository)."
-  version: "1.0.3"
+  version: "1.0.4"
   title: "Go Proxy"
   contact:
     name: "maintainer"


### PR DESCRIPTION
# Description

## [1.0.4] - 2022-03-17
### Changed
- Updated:
  - `golang.org/x/sys`  to `v0.0.0-20220317061510-51cd9980dadf` (indirect dependency)

### Fixed
- MacOS build by updating `golang.org/x/sys`.

Closes #11

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).

# How Has This Been Tested?

- [x] `make build`

**Run Configuration**:
- Go Proxy version: `1.0.3`
- Go version: `1.18`
- Operating system: `macOS`
- Processor architecture: `amd64`

# Checklist:

- [x] Pull request is linked with the corresponding issue.
- [x] My code follows the style guidelines of this project.
- [x] My change is documented in `CHANGELOG.md`.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation (`README.md`, `openapi.yaml`).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

@schenkova @bafrnec
